### PR TITLE
Fix UB

### DIFF
--- a/source/plutovg-paint.c
+++ b/source/plutovg-paint.c
@@ -30,7 +30,9 @@ static void plutovg_gradient_copy(plutovg_gradient_t* gradient, const plutovg_gr
     gradient->matrix = source->matrix;
     gradient->opacity = source->opacity;
     plutovg_array_ensure(gradient->stops, source->stops.size);
-    memcpy(gradient->stops.data, source->stops.data, source->stops.size * sizeof(plutovg_gradient_stop_t));
+    if (gradient->stops.data != 0) {
+        memcpy(gradient->stops.data, source->stops.data, source->stops.size * sizeof(plutovg_gradient_stop_t));
+    }
     memcpy(gradient->values, source->values, sizeof(source->values));
 }
 

--- a/source/plutovg-rle.c
+++ b/source/plutovg-rle.c
@@ -25,7 +25,9 @@ void plutovg_rle_copy(plutovg_rle_t* rle, const plutovg_rle_t* source)
 {
     plutovg_array_clear(rle->spans);
     plutovg_array_ensure(rle->spans, source->spans.size);
-    memcpy(rle->spans.data, source->spans.data, source->spans.size * sizeof(plutovg_span_t));
+    if (rle->spans.data != 0) {
+        memcpy(rle->spans.data, source->spans.data, source->spans.size * sizeof(plutovg_span_t));
+    }
     rle->spans.size = source->spans.size;
     rle->x = source->x;
     rle->y = source->y;

--- a/source/plutovg-stroke.c
+++ b/source/plutovg-stroke.c
@@ -25,7 +25,9 @@ void plutovg_stroke_data_copy(plutovg_stroke_data_t* strokedata, const plutovg_s
     strokedata->miterlimit = source->miterlimit;
     strokedata->dash.offset = source->dash.offset;
     plutovg_array_ensure(strokedata->dash, source->dash.size);
-    memcpy(strokedata->dash.data, source->dash.data, source->dash.size * sizeof(double));
+    if (strokedata->dash.data != 0) {
+        memcpy(strokedata->dash.data, source->dash.data, source->dash.size * sizeof(double));
+    }
     strokedata->dash.size = source->dash.size;
 }
 


### PR DESCRIPTION
This fix might not be correct, nor does it fix all the UB. At least `examples/smiley` won't crash now.

To reproduce, compile the project with `-fsanitize=undefined` and run `smiley`.

UB=C undefined behavior