### PR TITLE
Allow disabling image loading and saving functionalities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ if(MATH_LIBRARY)
     target_link_libraries(plutovg PRIVATE ${MATH_LIBRARY})
 endif()
 
+option(PLUTOVG_USE_STB_IMAGE "Use stb_image" ON)
+if(PLUTOVG_USE_STB_IMAGE)
+    target_compile_definitions(plutovg PUBLIC PLUTOVG_USE_STB_IMAGE)
+endif()
+
 target_compile_definitions(plutovg PRIVATE PLUTOVG_BUILD)
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(plutovg PUBLIC PLUTOVG_BUILD_STATIC)

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,10 @@ if get_option('default_library') == 'static'
     plutovg_compile_args += ['-DPLUTOVG_BUILD_STATIC']
 endif
 
+if get_option('use_stb_image')
+    plutovg_c_args += ['-DPLUTOVG_USE_STB_IMAGE']
+endif
+
 plutovg_sources = [
     'source/plutovg-blend.c',
     'source/plutovg-canvas.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('examples', type : 'feature', value : 'auto')
 option('tests', type : 'feature', value : 'auto')
+option('use_stb_image', type : 'boolean', value : true)


### PR DESCRIPTION
I am testing out PlutoSVG to render OT-SVG fonts in Lite XL. I'm impressed by the results (it did work) but I've noticed a 400kb increase in the binary size, in -O3 stripped. I then noticed that plutovg is vendoring stb_image to load surfaces from images and write surfaces to files. I am only planning to use Pluto(S)VG to render graphics to memory, so I didn't need to stb_image and stb_image_write to read and write images.

This PR includes the `PLUTOVG_USE_STB_IMAGE` (CMake) and `use_stb_image` (meson) options to enable / disable image support. This would also indirectly allow the library to support other image libraries in the future, like how [nanovg/fontstash.h](https://github.com/memononen/nanovg/blob/master/src/fontstash.h) supports FreeType and stbtt for rendering text. The following screenshot shows 300kb being saved by just omitting stb_image.h and stb_image_write.h.

| stb_image included | stb_image not included |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/bfa3113d-b1ed-4356-9cf5-6a82b18ea313) | ![image](https://github.com/user-attachments/assets/99fd218a-16bd-4006-98df-a546f294a756) |
