### PR TITLE
Fixes link error on Linux & BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(MATH_LIBRARY)
     target_link_libraries(plutovg PRIVATE m)
 endif()
 
+if(LINUX) 
+    target_link_libraries(plutovg PRIVATE pthread)
+endif()
+
 target_compile_definitions(plutovg PRIVATE PLUTOVG_BUILD)
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(plutovg PUBLIC PLUTOVG_BUILD_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ if(LINUX)
     target_link_libraries(plutovg PRIVATE pthread)
 endif()
 
+if(BSD)
+    target_link_libraries(plutovg PRIVATE stdthreads)
+endif()
+
 target_compile_definitions(plutovg PRIVATE PLUTOVG_BUILD)
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(plutovg PUBLIC PLUTOVG_BUILD_STATIC)
@@ -125,6 +129,14 @@ set(plutovg_pc_libs_private "")
 
 if(MATH_LIBRARY)
     string(APPEND plutovg_pc_libs_private " -lm")
+endif()
+
+if(LINUX)
+    string(APPEND plutovg_pc_libs_private " -lpthread")
+endif()
+
+if(BSD)
+    string(APPEND plutovg_pc_libs_private " -lstdthreads")
 endif()
 
 if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
Since on Linux the [threads.h functionality is implemented on top of pthread](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/pthread/mtx_lock.c;h=7318d4249e080fe8902d0f7954c7713c3405c3fc;hb=refs/heads/master) you need to link explicitly it to make sure it works all around.