### PR TITLE
Silence deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ set(PLUTOVG_VERSION_MICRO 3)
 
 project(plutovg LANGUAGES C VERSION ${PLUTOVG_VERSION_MAJOR}.${PLUTOVG_VERSION_MINOR}.${PLUTOVG_VERSION_MICRO})
 
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(PLUTOVG_MAINPROJECT ON)
+else()
+  set(PLUTOVG_MAINPROJECT OFF)
+endif()
+
+option(PLUTOVG_INSTALL "Enable installation of PlutoVG" ${PLUTOVG_MAINPROJECT})
+
 set(plutovg_sources
     source/plutovg-blend.c
     source/plutovg-canvas.c
@@ -90,7 +98,7 @@ if(NOT PLUTOVG_ENABLE_IMAGE_WRITE)
     target_compile_definitions(plutovg PRIVATE PLUTOVG_DISABLE_IMAGE_WRITE)
 endif()
 
-if(MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+if(MSVC OR (CMAKE_C_COMPILER_ID STREQUAL "Clang"))
     target_compile_definitions(plutovg PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
@@ -105,74 +113,76 @@ write_basic_package_version_file(plutovgConfigVersion.cmake
     COMPATIBILITY SameMajorVersion
 )
 
-install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/plutovg.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutovg
-)
+if (PLUTOVG_INSTALL)
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/plutovg.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutovg
+    )
 
-install(TARGETS plutovg
-    EXPORT plutovgTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+    install(TARGETS plutovg
+        EXPORT plutovgTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-install(EXPORT plutovgTargets
-    FILE plutovgTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
-    NAMESPACE plutovg::
-)
+    install(EXPORT plutovgTargets
+        FILE plutovgTargets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
+        NAMESPACE plutovg::
+    )
 
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
-)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
+    )
 
-export(EXPORT plutovgTargets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/plutovgTargets.cmake
-    NAMESPACE plutovg::
-)
+    export(EXPORT plutovgTargets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/plutovgTargets.cmake
+        NAMESPACE plutovg::
+    )
 
-file(RELATIVE_PATH plutovg_pc_prefix_relative
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    "${CMAKE_INSTALL_PREFIX}"
-)
+    file(RELATIVE_PATH plutovg_pc_prefix_relative
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        "${CMAKE_INSTALL_PREFIX}"
+    )
 
-set(plutovg_pc_cflags "")
-set(plutovg_pc_libs_private "")
+    set(plutovg_pc_cflags "")
+    set(plutovg_pc_libs_private "")
 
-if(MATH_LIBRARY)
-    string(APPEND plutovg_pc_libs_private " -lm")
+    if(MATH_LIBRARY)
+        string(APPEND plutovg_pc_libs_private " -lm")
+    endif()
+
+    if(Threads_FOUND AND CMAKE_THREAD_LIBS_INIT)
+        string(APPEND plutovg_pc_libs_private " ${CMAKE_THREAD_LIBS_INIT}")
+    endif()
+
+    if(NOT BUILD_SHARED_LIBS)
+        string(APPEND plutovg_pc_cflags " -DPLUTOVG_BUILD_STATIC")
+    endif()
+
+    string(CONFIGURE [[
+    prefix=${pcfiledir}/@plutovg_pc_prefix_relative@
+    includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+    libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+    Name: PlutoVG
+    Description: Tiny 2D vector graphics library in C
+    Version: @PROJECT_VERSION@
+
+    Cflags: -I${includedir}/plutovg@plutovg_pc_cflags@
+    Libs: -L${libdir} -lplutovg
+    Libs.private:@plutovg_pc_libs_private@
+    ]] plutovg_pc @ONLY)
+
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc" "${plutovg_pc}")
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
 endif()
-
-if(Threads_FOUND AND CMAKE_THREAD_LIBS_INIT)
-    string(APPEND plutovg_pc_libs_private " ${CMAKE_THREAD_LIBS_INIT}")
-endif()
-
-if(NOT BUILD_SHARED_LIBS)
-    string(APPEND plutovg_pc_cflags " -DPLUTOVG_BUILD_STATIC")
-endif()
-
-string(CONFIGURE [[
-prefix=${pcfiledir}/@plutovg_pc_prefix_relative@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-
-Name: PlutoVG
-Description: Tiny 2D vector graphics library in C
-Version: @PROJECT_VERSION@
-
-Cflags: -I${includedir}/plutovg@plutovg_pc_cflags@
-Libs: -L${libdir} -lplutovg
-Libs.private:@plutovg_pc_libs_private@
-]] plutovg_pc @ONLY)
-
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc" "${plutovg_pc}")
-
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-)
 
 option(PLUTOVG_BUILD_EXAMPLES "Build examples" ON)
 if(PLUTOVG_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ if(NOT PLUTOVG_ENABLE_IMAGE_WRITE)
     target_compile_definitions(plutovg PRIVATE PLUTOVG_DISABLE_IMAGE_WRITE)
 endif()
 
+if(MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    target_compile_definitions(plutovg PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/plutovgConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/plutovgConfig.cmake"

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,10 @@ plutovg_c_args += cc.get_supported_arguments(
     '-Wno-unused-function'
 )
 
+if cc.get_id() == 'msvc' or cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
+    plutovg_c_args += ['-D_CRT_SECURE_NO_WARNINGS']
+endif
+
 if get_option('font-face-cache-load').disabled()
     plutovg_c_args += ['-DPLUTOVG_DISABLE_FONT_FACE_CACHE_LOAD']
 endif


### PR DESCRIPTION
See: sammycage/plutosvg#35

Silences "deprecation" warnings from MSVC and clang.

Currently, generated warning by clang:
```
[build] E:/DEV/C++/Projects/Count-Engine-02/Count/vendor/PlutoSVG/plutovg/source/plutovg-font.c:141:16: warning: 'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [-Wdeprecated-declarations]
```

Technically MSVC doesn't need _CRT_SECURE_NO_WARNINGS because it is not generating any warnings for PlutoVG, I added it in case a warning is generated in a future version that requires _CRT_SECURE_NO_WARNINGS to silence.