### PR TITLE
check c11 threads.h presence before using

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(plutovg::plutovg ALIAS plutovg)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CheckIncludeFile)
 
 set_target_properties(plutovg PROPERTIES
     SOVERSION ${PLUTOVG_VERSION_MAJOR}
@@ -61,6 +62,10 @@ if(MATH_LIBRARY)
     target_link_libraries(plutovg PRIVATE m)
 endif()
 
+check_include_file("threads.h" HAVE_THREADS_H)
+if(HAVE_THREADS_H)
+    target_compile_definitions(plutovg PRIVATE HAVE_THREADS_H)
+endif()
 find_package(Threads)
 if(Threads_FOUND)
     target_link_libraries(plutovg PRIVATE Threads::Threads)

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,9 @@ threads_dep = dependency('threads', required: false)
 if threads_dep.found()
     plutovg_deps += [threads_dep]
 endif
+if cc.check_header('threads.h')
+    plutovg_c_args += ['-DHAVE_THREADS_H']
+endif
 
 plutovg_sources = [
     'source/plutovg-blend.c',

--- a/source/plutovg-font.c
+++ b/source/plutovg-font.c
@@ -119,7 +119,7 @@ typedef CRITICAL_SECTION plutovg_mutex_t;
 #define plutovg_mutex_unlock(mutex) LeaveCriticalSection(mutex)
 #define plutovg_mutex_destroy(mutex) DeleteCriticalSection(mutex)
 
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && defined(HAVE_THREADS_H) && !defined(__STDC_NO_THREADS__)
 
 #include <threads.h>
 


### PR DESCRIPTION
threads.h is provided by libc (glibc), not by gcc.