### PR TITLE
bump minimum required meson version to 1.3.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('plutovg', 'c',
     version: '1.3.0',
     license: 'MIT',
-    meson_version: '>=0.59.0',
+    meson_version: '>=1.3.0',
     default_options: ['c_std=gnu11,c11']
 )
 


### PR DESCRIPTION
c_std accepting a list starts with meson-v1.3.0