### PR TITLE
 plutovgConfig.cmake.in: add Threads find_dependency

### DIFF
--- a/cmake/plutovgConfig.cmake.in
+++ b/cmake/plutovgConfig.cmake.in
@@ -1,3 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/plutovgTargets.cmake")


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/pull/8150
Please check for Threads, so target Threads::Threads would be resolved during usage of plutovg for lunasvg.
```
C:\Windows\System32\tar.exe -xf C:\Users\Admin\AppData\Local\.xmake\cache\packages\2509\l\lunasvg\v3.5.0\v3.5.0.tar.gz
  => download https://github.com/sammycage/lunasvg/archive/refs/tags/v3.5.0.tar.gz .. ok
checkinfo: cannot runv(pkgconf.exe --version), No such file or directory
checking for pkgconf ... no
checkinfo: cannot runv(pkgconf.exe --version), No such file or directory
checking for pkgconf ... no
checkinfo: cannot runv(pkg-config.exe --version), No such file or directory
checking for pkg-config ... no
checkinfo: cannot runv(pkg-config.exe --version), No such file or directory
checking for pkg-config ... no
C:\Users\Admin\scoop\shims\cmake.exe -DLUNASVG_BUILD_EXAMPLES=OFF -DUSE_SYSTEM_PLUTOVG=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=C:\Users\Admin\AppData\Local\.xmake\packages\l\lunasvg\v3.5.0\488fef98495e4652b495b8ed63d9f5bf -DCMAKE_INSTALL_LIBDIR:PATH=lib -G Ninja -DCMAKE_MAKE_PROGRAM=C:\Users\Admin\scoop\shims\ninja.exe -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DCMAKE_C_COMPILER=C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/Llvm/x64/bin/clang-cl.exe" "-DCMAKE_CXX_COMPILER=C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/Llvm/x64/bin/clang-cl.exe" -DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=C:/Users/Admin/AppData/Local/.xmake/cache/packages/2509/l/lunasvg/v3.5.0/source/build_488fef98/pdb -DCMAKE_PDB_OUTPUT_DIRECTORY=C:/Users/Admin/AppData/Local/.xmake/cache/packages/2509/l/lunasvg/v3.5.0/source/build_488fef98/pdb -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_STATIC_LINKER_FLAGS_RELEASE=/machine:x64 "-DCMAKE_C_FLAGS_RELEASE=/DWIN32 /D_WINDOWS /O2 /Ob2 /DNDEBUG -MD" "-DCMAKE_SHARED_LINKER_FLAGS_RELEASE=/machine:x64 /INCREMENTAL:NO" "-DCMAKE_CXX_FLAGS_RELEASE=/DWIN32 /D_WINDOWS /GR /EHsc /O2 /Ob2 /DNDEBUG -MD" "-DCMAKE_EXE_LINKER_FLAGS_RELEASE=/machine:x64 /INCREMENTAL:NO" C:\Users\Admin\AppData\Local\.xmake\cache\packages\2509\l\lunasvg\v3.5.0\source
-- The CXX compiler identification is Clang 19.1.5 with MSVC-like command-line
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/Llvm/x64/bin/clang-cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (3.8s)
CMake Error at C:/Users/Admin/AppData/Local/.xmake/packages/p/plutovg/v1.3.1/28c41867c88f456fa3e93f1f7a5c2590/lib/cmake/plutovg/plutovgTargets.cmake:61 (set_target_properties):
  The link interface of target "plutovg::plutovg" contains:

    Threads::Threads

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  C:/Users/Admin/AppData/Local/.xmake/packages/p/plutovg/v1.3.1/28c41867c88f456fa3e93f1f7a5c2590/lib/cmake/plutovg/plutovgConfig.cmake:27 (include)
  CMakeLists.txt:11 (find_package)


-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_C_COMPILER
    CMAKE_C_FLAGS_RELEASE
```