### PR TITLE
Apply bilinear sampling to transformed plain (non-tiled) textures

### DIFF
--- a/source/plutovg-blend.c
+++ b/source/plutovg-blend.c
@@ -766,57 +766,6 @@ static void blend_untransformed_argb(plutovg_surface_t* surface, plutovg_operato
 }
 
 #define FIXED_SCALE (1 << 16)
-static void blend_transformed_argb(plutovg_surface_t* surface, plutovg_operator_t op, const texture_data_t* texture, const plutovg_span_buffer_t* span_buffer)
-{
-    composition_function_t func = composition_table[op];
-    uint32_t buffer[BUFFER_SIZE];
-
-    int image_width = texture->width;
-    int image_height = texture->height;
-
-    int fdx = (int)(texture->matrix.a * FIXED_SCALE);
-    int fdy = (int)(texture->matrix.b * FIXED_SCALE);
-
-    int count = span_buffer->spans.size;
-    const plutovg_span_t* spans = span_buffer->spans.data;
-    while(count--) {
-        uint32_t* target = (uint32_t*)(surface->data + spans->y * surface->stride) + spans->x;
-
-        const float cx = spans->x + 0.5f;
-        const float cy = spans->y + 0.5f;
-
-        int x = (int)((texture->matrix.c * cy + texture->matrix.a * cx + texture->matrix.e) * FIXED_SCALE);
-        int y = (int)((texture->matrix.d * cy + texture->matrix.b * cx + texture->matrix.f) * FIXED_SCALE);
-
-        int length = spans->len;
-        const int coverage = (spans->coverage * texture->const_alpha) >> 8;
-        while(length) {
-            int l = plutovg_min(length, BUFFER_SIZE);
-            const uint32_t* end = buffer + l;
-            uint32_t* b = buffer;
-            while(b < end) {
-                int px = x >> 16;
-                int py = y >> 16;
-                if((px < 0) || (px >= image_width) || (py < 0) || (py >= image_height)) {
-                    *b = 0x00000000;
-                } else {
-                    *b = ((const uint32_t*)(texture->data + py * texture->stride))[px];
-                }
-
-                x += fdx;
-                y += fdy;
-                ++b;
-            }
-
-            func(target, l, buffer, coverage);
-            target += l;
-            length -= l;
-        }
-
-        ++spans;
-    }
-}
-
 static void blend_untransformed_tiled_argb(plutovg_surface_t* surface, plutovg_operator_t op, const texture_data_t* texture, const plutovg_span_buffer_t* span_buffer)
 {
     composition_function_t func = composition_table[op];
@@ -1000,6 +949,71 @@ static void blend_transformed_bilinear_tiled_argb(plutovg_surface_t* surface, pl
     }
 }
 
+static void blend_transformed_bilinear_argb(plutovg_surface_t* surface, plutovg_operator_t op, const texture_data_t* texture, const plutovg_span_buffer_t* span_buffer)
+{
+    composition_function_t func = composition_table[op];
+    uint32_t buffer[BUFFER_SIZE];
+
+    int image_width = texture->width;
+    int image_height = texture->height;
+
+    int fdx = (int)(texture->matrix.a * FIXED_SCALE);
+    int fdy = (int)(texture->matrix.b * FIXED_SCALE);
+
+    int count = span_buffer->spans.size;
+    const plutovg_span_t* spans = span_buffer->spans.data;
+    while(count--) {
+        uint32_t* target = (uint32_t*)(surface->data + spans->y * surface->stride) + spans->x;
+
+        const float cx = spans->x + 0.5f;
+        const float cy = spans->y + 0.5f;
+
+        int fx = (int)((texture->matrix.c * cy + texture->matrix.a * cx + texture->matrix.e) * FIXED_SCALE);
+        int fy = (int)((texture->matrix.d * cy + texture->matrix.b * cx + texture->matrix.f) * FIXED_SCALE);
+
+        fx -= HALF_POINT;
+        fy -= HALF_POINT;
+
+        const int coverage = (spans->coverage * texture->const_alpha) >> 8;
+        int length = spans->len;
+        while(length) {
+            int l = plutovg_min(length, BUFFER_SIZE);
+            const uint32_t* end = buffer + l;
+            uint32_t* b = buffer;
+            while(b < end) {
+                int x1 = fx >> 16;
+                int y1 = fy >> 16;
+                int x2 = x1 + 1;
+                int y2 = y1 + 1;
+
+                int x1_valid = (x1 >= 0 && x1 < image_width);
+                int x2_valid = (x2 >= 0 && x2 < image_width);
+                const uint32_t* s1 = (y1 >= 0 && y1 < image_height) ? (const uint32_t*)(texture->data + y1 * texture->stride) : NULL;
+                const uint32_t* s2 = (y2 >= 0 && y2 < image_height) ? (const uint32_t*)(texture->data + y2 * texture->stride) : NULL;
+
+                uint32_t tl = (s1 && x1_valid) ? s1[x1] : 0u;
+                uint32_t tr = (s1 && x2_valid) ? s1[x2] : 0u;
+                uint32_t bl = (s2 && x1_valid) ? s2[x1] : 0u;
+                uint32_t br = (s2 && x2_valid) ? s2[x2] : 0u;
+
+                int distx = (fx & 0x0000ffff) >> 8;
+                int disty = (fy & 0x0000ffff) >> 8;
+                *b = interpolate_4_pixels(tl, tr, bl, br, distx, disty);
+
+                fx += fdx;
+                fy += fdy;
+                ++b;
+            }
+
+            func(target, l, buffer, coverage);
+            target += l;
+            length -= l;
+        }
+
+        ++spans;
+    }
+}
+
 static void plutovg_blend_color(plutovg_canvas_t* canvas, const plutovg_color_t* color, const plutovg_span_buffer_t* span_buffer)
 {
     plutovg_state_t* state = canvas->state;
@@ -1112,7 +1126,7 @@ static void plutovg_blend_texture(plutovg_canvas_t* canvas, const plutovg_textur
         }
     } else {
         if(texture->type == PLUTOVG_TEXTURE_TYPE_PLAIN) {
-            blend_transformed_argb(canvas->surface, state->op, &data, span_buffer);
+            blend_transformed_bilinear_argb(canvas->surface, state->op, &data, span_buffer);
         } else if(fabsf(matrix->b) > 1e-6f || fabsf(matrix->c) > 1e-6f) {
             blend_transformed_bilinear_tiled_argb(canvas->surface, state->op, &data, span_buffer);
         } else {


### PR DESCRIPTION
### Summary

Applies bilinear sampling to `PLUTOVG_TEXTURE_TYPE_PLAIN` textures when rendered with a non-identity matrix. Same fix you already landed in dabf47cff0 for the tiled variants, extended to the path that SVG `<image>` elements actually take.

### Motivation

Embedded raster images in SVG — `<image href="...">` rendered at a smaller size than the source bitmap — currently produce visibly pixelated output: stair-stepped diagonals, jagged text. Root cause was raised in sammycage/lunasvg#213: `blend_transformed_argb` samples a single pixel via integer truncation.

Your tiled-texture refactor in dabf47cff0 added a proper bilinear path, but the dispatcher only routes there for `type != PLAIN` (patterns, not images). `<image>` elements come through lunasvg as PLAIN textures, so they still hit the old nearest-neighbour code.

### Change

- New function `blend_transformed_bilinear_argb`, mirrors `blend_transformed_bilinear_tiled_argb` but with zero-out-of-bounds at the image edges (matching the old `blend_transformed_argb` semantics) instead of the modulo wrap that the tiled variant uses.
- Dispatcher in `plutovg_blend_texture`: PLAIN + non-identity matrix → new bilinear function.
- Removed the legacy `blend_transformed_argb` — no remaining callers.

### Why bilinear is unconditional here

In the tiled refactor you gated bilinear on `rotation || shear`, preserving pixel-perfect behaviour for integer-scale tile fills. That matters for `<pattern>` semantics — users expect crisp tile boundaries when they author a pixel-aligned repeating pattern.

For PLAIN-type `<image>`, the expectation is the opposite: bitmaps embedded in an SVG should smooth-scale on any non-identity transform. All major browsers do this for `<image>` by default (the `image-rendering` CSS property is required to opt back into nearest). So we always go through the bilinear path here.

Happy to follow up with a stricter gate (e.g. determinant-based, or a public knob) if you'd prefer.

### Test plan

- Built locally on macOS arm64 / clang.
- Ad-hoc downscale harness against a 1332×1332 JPEG and a 624×198 RGBA PNG rendered to 100px / 200px / 400px. Before: jagged diagonals, aliased text. After: smooth, anti-aliased output.
- `smiley` example still renders identically (no PLAIN+transform path exercised there).

Fixes sammycage/lunasvg#213.