### PR TITLE
Handle realloc failure in ft_stroke_border_grow

### DIFF
--- a/source/plutovg-ft-stroker.c
+++ b/source/plutovg-ft-stroker.c
@@ -247,15 +247,26 @@ static PVG_FT_Error ft_stroke_border_grow(PVG_FT_StrokeBorder border,
 
     if (new_max > old_max) {
         PVG_FT_UInt cur_max = old_max;
+        PVG_FT_Vector* new_pts;
+        PVG_FT_Byte*   new_tags;
 
         while (cur_max < new_max) cur_max += (cur_max >> 1) + 16;
 
-        border->points = (PVG_FT_Vector*)realloc(border->points,
-                                                cur_max * sizeof(PVG_FT_Vector));
-        border->tags =
-            (PVG_FT_Byte*)realloc(border->tags, cur_max * sizeof(PVG_FT_Byte));
+        new_pts = (PVG_FT_Vector*)realloc(border->points,
+                                          cur_max * sizeof(PVG_FT_Vector));
+        if (!new_pts) {
+            error = -3;  // PVG_FT_THROW( Out_Of_Memory );
+            goto Exit;
+        }
+        border->points = new_pts;
 
-        if (!border->points || !border->tags) goto Exit;
+        new_tags = (PVG_FT_Byte*)realloc(border->tags,
+                                         cur_max * sizeof(PVG_FT_Byte));
+        if (!new_tags) {
+            error = -3;  // PVG_FT_THROW( Out_Of_Memory );
+            goto Exit;
+        }
+        border->tags = new_tags;
 
         border->max_points = cur_max;
     }


### PR DESCRIPTION
`ft_stroke_border_grow` initializes `error = 0` and never updates it, so any realloc failure returns success to the caller. Two distinct failure modes follow:

1. Both reallocs fail. Callers (`ft_stroke_border_lineto`, `_conicto`, `_cubicto`) see `error == 0` and write into `border->points + border->num_points` and `border->tags + border->num_points`, dereferencing NULL.
2. One realloc succeeds, the other fails. The successful side gets assigned to `border->points` while `border->tags` retains a stale pointer, leaving the two arrays out of sync. `border->max_points` is not updated (it only updates after both checks), so the inconsistency is silent until the next grow recomputes against the stale capacity.

The fix saves each realloc result to a local before assigning, returns `Out_Of_Memory` on failure (matching the FreeType throw style used elsewhere in this file at lines 1713 and 1870), and only commits to `border->points`/`tags` after each realloc succeeds. When `tags` realloc fails after `points` succeeded, `border->points` keeps the grown buffer (harmless over-allocation) and `border->max_points` stays at the old value so the next grow retries cleanly.