### PR TITLE
Bail out on malloc failure and cap pool growth in raster render

### DIFF
--- a/source/plutovg-ft-raster.c
+++ b/source/plutovg-ft-raster.c
@@ -1879,8 +1879,12 @@ void PVG_FT_Outline_Get_CBox(const PVG_FT_Outline* outline, PVG_FT_BBox* acbox)
           if(worker.skip_spans < 0)
               rendered_spans += -worker.skip_spans;
           worker.skip_spans = rendered_spans;
+          if(length > (size_t)1 << 27) /* cap at 256 MB */
+              break;
           length *= 2;
           void* heap = malloc(length);
+          if(!heap)
+              break;
           error = gray_raster_render(&worker, heap, length, params);
           free(heap);
       }


### PR DESCRIPTION
`PVG_FT_Raster_Render`'s growth loop passes `malloc(length)` straight to `gray_raster_render` without a NULL check. On OOM `gray_init_cells` assigns `ras.buffer = NULL`, then `gray_convert_glyph` writes `ras.ycells = (PCell*)ras.buffer; ras.ycells[yindex] = NULL;` — NULL deref.

Separately, `length *= 2` doubles without cap. Pathological geometry (a path that overflows the cell pool at every size) loops until `length` wraps `size_t` on 32-bit builds, at which point `malloc(0)` is implementation-defined and the subsequent worker walks past the returned region.

Two-line fix: break the loop on `malloc` returning NULL, and break before doubling once `length` would exceed 256 MB (15 doublings from `PVG_FT_MINIMUM_POOL_SIZE = 8192`).