### PR TITLE
Optional build flag to compile out the image-write side

### DIFF
--- a/source/plutovg-surface.c
+++ b/source/plutovg-surface.c
@@ -1,9 +1,11 @@
 #include "plutovg-private.h"
 #include "plutovg-utils.h"
 
+#ifndef PLUTOVG_DISABLE_IMAGE_WRITE
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "plutovg-stb-image-write.h"
+#endif
 
 #define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
@@ -195,6 +197,7 @@ void plutovg_surface_clear(plutovg_surface_t* surface, const plutovg_color_t* co
     }
 }
 
+#ifndef PLUTOVG_DISABLE_IMAGE_WRITE
 static void plutovg_surface_write_begin(const plutovg_surface_t* surface)
 {
     plutovg_convert_argb_to_rgba(surface->data, surface->data, surface->width, surface->height, surface->stride);
@@ -236,6 +239,7 @@ bool plutovg_surface_write_to_jpg_stream(const plutovg_surface_t* surface, pluto
     plutovg_surface_write_end(surface);
     return success;
 }
+#endif /* !PLUTOVG_DISABLE_IMAGE_WRITE */
 
 void plutovg_convert_argb_to_rgba(unsigned char* dst, const unsigned char* src, int width, int height, int stride)
 {


### PR DESCRIPTION
The four `plutovg_surface_write_to_*` functions and the `stb_image_write.h` translation unit they pull in add weight to every build, even for consumers that handle PNG/JPEG encoding themselves (via libpng, libjpeg-turbo, libwebp, etc.) and never call into the write side.

This PR adds `PLUTOVG_DISABLE_IMAGE_WRITE`, an opt-out compile-time flag. The default (macro undefined) is unchanged, so existing builds stay identical. Defining `-DPLUTOVG_DISABLE_IMAGE_WRITE` compiles out the four function bodies and skips the `stb_image_write.h` include in `plutovg-surface.c`. A negative opt-out macro for default-on functionality needs no default `#define` and keeps the default behavior implicit, matching the existing flag conventions. The four prototypes stay declared in `include/plutovg.h`, preserving source compatibility; the link step surfaces any unfulfilled reference with a clear error.

Measured on a default CMake Release build (static lib, no other flags) on the v1.3.3 tree:

| Build | `libplutovg.a` | `plutovg_surface_write_*` symbols | `surface.c` text section |
|---|---:|---:|---:|
| Baseline (this branch's parent) | 450,004 B | 4 | 152,694 B |
| Default (this branch, no flags) | 450,004 B | 4 | 152,694 B |
| `-DPLUTOVG_DISABLE_IMAGE_WRITE` | **399,658 B** | **0** | **110,768 B** |

The default build is byte-identical to baseline. Gate-off drops ~50 KB and all four write-side symbols disappear cleanly. Mirrors `PLUTOVG_BUILD_STATIC` in spirit: a compile-time linkage knob consumers opt into based on what they need.
