### PR TITLE
Build-time knob for the FT raster scratch pool

### DIFF
--- a/source/plutovg-ft-raster.c
+++ b/source/plutovg-ft-raster.c
@@ -77,7 +77,9 @@ typedef ptrdiff_t  PVG_FT_PtrDist;
 #include <stdlib.h>
 #include <limits.h>
 
+#ifndef PVG_FT_MINIMUM_POOL_SIZE
 #define PVG_FT_MINIMUM_POOL_SIZE (1024 * 8)
+#endif
 #define PVG_FT_MAXIMUM_POOL_SIZE (1024 * 1024 * 8)
 
 #define RAS_ARG   PWorker  worker


### PR DESCRIPTION
`PVG_FT_MINIMUM_POOL_SIZE` defaults to 8 KB. When the rasterizer's stack pool overflows, `PVG_FT_Raster_Render` falls back to a doubling `malloc` plus a re-render pass with `skip_spans` accounting. For workloads that draw large filled shapes (chart backgrounds, large filled bars, plot rectangles wider than ~256 cells per band), overflow triggers on most fills, and the allocator + retry cost dominates the render.

This PR keeps the 8 KB default but lets downstream consumers override the constant at compile time with `-DPVG_FT_MINIMUM_POOL_SIZE=N`. Embedded users with tight stack budgets keep today's footprint; consumers with stack headroom opt into a larger pool and skip the malloc-fallback path entirely. The change is two added lines, zero modified.

Default build is provably unchanged: `cmp` against the pre-patch `plutovg-ft-raster.c.o` returns zero differences (byte-identical object file). Override builds were verified by inspecting the resulting `sub $imm, %rsp` stack-frame allocation via `objdump`: `-DPVG_FT_MINIMUM_POOL_SIZE=32768` produces `sub $0x8000, %rsp`, default produces `sub $0x2000, %rsp`, `-DPVG_FT_MINIMUM_POOL_SIZE=4096` produces `sub $0x1000, %rsp`. The override flows through to the actual stack-frame size.

Bench on a chart-rendering workload (release-build PHP extension consuming plutovg, `-O2 -g`, 200 iterations per scenario, 5 warmup, baseline / candidate sandwiched around a working-tree revert so both runs share system noise), toggling only the pool size from 8 KB to 32 KB:

| Scenario | pool=8K (default) | pool=32K | Δ min |
|---|---:|---:|---:|
| svg_to_png (500 elements) | 32.59 ms | 29.05 ms | **-10.8%** |
| label_jpeg (~120 shapes) | 8.64 ms | 7.78 ms | **-9.9%** |
| basic_chart (sparse) | 6.61 ms | 6.66 ms | noise |

Charts with sparse primitives see no benefit (they already fit the 8 KB pool); the gain concentrates where overflow is the bottleneck. The cost is stack: a 32 KB setting uses 24 KB more stack per `render()` call than the default. Consumers opting in trade allocator pressure for stack footprint.
