### PR TITLE
cmake, meson: tweak disabling examples' build for rimage-write option:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ add_library(plutovg::plutovg ALIAS plutovg)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(CheckIncludeFile)
-include(CMakeDependentOption)
 
 set_target_properties(plutovg PROPERTIES
     SOVERSION ${PLUTOVG_VERSION_MAJOR}
@@ -171,7 +170,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 
-cmake_dependent_option(PLUTOVG_BUILD_EXAMPLES "Build examples" ON PLUTOVG_ENABLE_IMAGE_WRITE OFF)
+option(PLUTOVG_BUILD_EXAMPLES "Build examples" ON)
 if(PLUTOVG_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_executable(smiley smiley.c)
-target_link_libraries(smiley plutovg)
+if(PLUTOVG_ENABLE_IMAGE_WRITE)
+   add_executable(smiley smiley.c)
+   target_link_libraries(smiley plutovg)
+endif()

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,1 +1,3 @@
-executable('smiley', 'smiley.c', dependencies: plutovg_dep)
+if get_option('image-write').enabled()
+   executable('smiley', 'smiley.c', dependencies: plutovg_dep)
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('plutovg', 'c',
     version: '1.3.3',
     license: 'MIT',
-    meson_version: '>=1.3.0',
+    meson_version: '>=1.0.0',
     default_options: ['c_std=gnu11']
 )
 
@@ -79,9 +79,7 @@ meson.override_dependency('plutovg', plutovg_dep)
 install_headers('include/plutovg.h', subdir: 'plutovg')
 
 if not get_option('examples').disabled()
-  if get_option('image-write').enabled()
     subdir('examples')
-  endif
 endif
 
 pkgmod = import('pkgconfig')


### PR DESCRIPTION
Reverts cmake_dependent_option(), only disables build of smiley example
if image-write is disabled which is more flexible if more examples ever
get added in the future.

This is a follow-up / clean-up to #79 
