### PR TITLE
Use <limits.h> for PATH_MAX instead of <linux/limits.h>

### DIFF
--- a/source/plutovg-font.c
+++ b/source/plutovg-font.c
@@ -697,10 +697,9 @@ plutovg_font_face_t* plutovg_font_face_cache_get(plutovg_font_face_cache_t* cach
 #include <unistd.h>
 #include <dirent.h>
 
-#ifdef __linux__
-#include <linux/limits.h>
-#else
 #include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 4096
 #endif
 
 #include <sys/mman.h>


### PR DESCRIPTION
`plutovg-font.c` includes `<linux/limits.h>` under `__linux__` just to get `PATH_MAX` for the font-directory path buffer. That's a kernel UAPI header: on musl targets like Alpine it isn't present unless the `linux-headers` package is installed, so the file fails to compile on an otherwise complete musl toolchain (clang or gcc):

```
source/plutovg-font.c:701:10: fatal error: 'linux/limits.h' file not found
  701 | #include <linux/limits.h>
```

`<limits.h>` already defines `PATH_MAX` on glibc, musl, and the BSDs, so the `__linux__` special-case isn't needed for the one define it was guarding. This switches to `<limits.h>` unconditionally, with a `4096` fallback for any libc that leaves `PATH_MAX` undefined. No change on glibc.

Found while building a project that vendors plutovg for static/musl (Alpine) targets.