### PR TITLE
Keep close point aligned after path transforms

### DIFF
--- a/source/plutovg-path.c
+++ b/source/plutovg-path.c
@@ -370,6 +370,8 @@ void plutovg_path_transform(plutovg_path_t* path, const plutovg_matrix_t* matrix
             break;
         }
     }
+    if(path->elements.size > 0)
+        plutovg_matrix_map_point(matrix, &path->start_point, &path->start_point);
 }
 
 void plutovg_path_add_path(plutovg_path_t* path, const plutovg_path_t* source, const plutovg_matrix_t* matrix)


### PR DESCRIPTION
## Summary

`plutovg_path_transform()` maps every stored path element, but it left the cached subpath start unchanged. A later `plutovg_path_close()` therefore appended the pre-transform start point instead of closing to the transformed subpath origin.

This change maps `start_point` alongside the stored elements for non-empty paths. Empty-path behavior and the public API remain unchanged.

## Reproduction

Using only the public API:

1. Move to `(1, 2)` and draw a line.
2. Translate the path by `(10, 20)` with `plutovg_path_transform()`.
3. Call `plutovg_path_close()` and inspect the close command with the path iterator.

Before this change, the close point is `(1, 2)`. After the change, it is the expected `(11, 22)`.

## Testing

- MinGW GCC 8 CMake Release build and `smiley` example
- WSL GCC 13 CMake and Meson Release builds with examples
- Public-API regression matrix covering translation, multiple subpaths, empty paths, new subpaths after a transform, existing close commands, and consecutive transforms
- ASan and UBSan regression run
